### PR TITLE
Fix bug: take only base name of a zip file when full path is supplied

### DIFF
--- a/create_flashable_firmware.py
+++ b/create_flashable_firmware.py
@@ -166,6 +166,7 @@ def vendor_updater():
 
 def make_zip():
     rom, process = arg_parse()
+    rom = path.basename(rom)
     with open("out/META-INF/com/google/android/updater-script", 'r') as i:
         codename = str(i.readlines()[7].split('/', 3)[2]).split(':', 1)[0].replace('_', '-')
     print("Creating " + process + " zip from " + rom + " for " + codename)
@@ -214,5 +215,6 @@ def main():
     make_zip()
 
 
-arg_parse()
-main()
+if __name__ == '__main__':
+    arg_parse()
+    main()


### PR DESCRIPTION
When supplied with path to a zip file instead of pure file name, make_zip() method crashes due to invalid filename.

I also added `if __name__ == '__main__':` construct as it is standard for runnable scripts.