### PR TITLE
Fix some Windows specific issues

### DIFF
--- a/xiaomi_flashable_firmware_creator/extractors/handlers/android_one_zip.py
+++ b/xiaomi_flashable_firmware_creator/extractors/handlers/android_one_zip.py
@@ -46,7 +46,6 @@ class AndroidOneZip(BaseHandler):
         :param files_to_extract: a list of files to extract
         :return:
         """
-        Path(self._tmp_dir / "payload.bin").unlink()
         Path(self._tmp_dir / "firmware-update").mkdir(parents=True, exist_ok=True)
         files_to_extract: set = set(self.files).intersection(set(files_to_extract))
         for file in files_to_extract:
@@ -58,3 +57,4 @@ class AndroidOneZip(BaseHandler):
             ) as out_f:
                 parse_payload(self.payload, partition, out_f)
         self.payload_file.close()
+        Path(self._tmp_dir / "payload.bin").unlink()

--- a/xiaomi_flashable_firmware_creator/firmware_creator.py
+++ b/xiaomi_flashable_firmware_creator/firmware_creator.py
@@ -424,7 +424,6 @@ class FlashableFirmwareCreator:
         :return:
         """
         out = Path(f"{self._out_dir}/result.zip")
-        partial_path = "/".join(out.parts[1:-1])
         make_archive(str(out.with_suffix("").absolute()), "zip", self._tmp_dir)
         if not out.exists():
             raise RuntimeError("Could not create result zip file!")

--- a/xiaomi_flashable_firmware_creator/firmware_creator.py
+++ b/xiaomi_flashable_firmware_creator/firmware_creator.py
@@ -425,7 +425,7 @@ class FlashableFirmwareCreator:
         """
         out = Path(f"{self._out_dir}/result.zip")
         partial_path = "/".join(out.parts[1:-1])
-        make_archive(f"/{partial_path}/{out.stem}", "zip", self._tmp_dir)
+        make_archive(str(out.with_suffix("").absolute()), "zip", self._tmp_dir)
         if not out.exists():
             raise RuntimeError("Could not create result zip file!")
         if not self.is_android_one:

--- a/xiaomi_flashable_firmware_creator/helpers/misc.py
+++ b/xiaomi_flashable_firmware_creator/helpers/misc.py
@@ -61,4 +61,4 @@ class ScriptTemplate(Template):
 
 
 def write_text_to_file(file: Union[str, Path], text: str):
-    Path(file).write_text(text, encoding="utf-8", newline="\n")
+    Path(file).write_bytes(text.encode("utf-8"))

--- a/xiaomi_flashable_firmware_creator/xiaomi_flashable_firmware_creator.py
+++ b/xiaomi_flashable_firmware_creator/xiaomi_flashable_firmware_creator.py
@@ -6,7 +6,7 @@ from argparse import ArgumentParser
 from xiaomi_flashable_firmware_creator.firmware_creator import FlashableFirmwareCreator
 
 
-def arg_parse() -> (str, str, str):
+def arg_parse() -> tuple[str, str, str]:
     """
     Parse command-line arguments.
 


### PR DESCRIPTION
The first commit avoids removing `payload.bin` while it's still in use, which is OK in Unix-like systems but disallowed in Windows; the second uses pathlib's `with_suffix` method to remove the `.zip` extension without explicitly forming paths in a platform-specific manner.