### PR TITLE
firmware_creator: Exclude mi_ext

### DIFF
--- a/xiaomi_flashable_firmware_creator/firmware_creator.py
+++ b/xiaomi_flashable_firmware_creator/firmware_creator.py
@@ -78,6 +78,7 @@ class FlashableFirmwareCreator:
             "product",
             "odm",
             "exaid",
+            "mi_ext",
             "dynamic_partitions_op_list",
             "metadata.pb",
         ]


### PR DESCRIPTION
This is included in some MIUI 14 zips.